### PR TITLE
[fix/learning-tasks-ui]: Fix Learning Tasks UI bugs

### DIFF
--- a/olim/database.py
+++ b/olim/database.py
@@ -514,12 +514,16 @@ def get_users() -> list[User]:
     Returns:
         List of User objects sorted by username
     """
-    return db.session.execute(
-        db.select(User)
-        .filter_by(is_deleted=False)
-        .filter(User.username != LLM_USER_USERNAME)
-        .order_by(User.username)
-    ).scalars()
+    return (
+        db.session.execute(
+            db.select(User)
+            .filter_by(is_deleted=False)
+            .filter(User.username != LLM_USER_USERNAME)
+            .order_by(User.username)
+        )
+        .scalars()
+        .all()
+    )
 
 
 def insert_user(username: str, hashed_password: str, role: str, creator: int, **kwargs) -> User:

--- a/olim/learning_tasks/states.py
+++ b/olim/learning_tasks/states.py
@@ -19,7 +19,7 @@ from ..database import (
     random_entries,
 )
 from ..entry_types.registry import get_entry_type_instance
-from ..functions import get_highlights, render_entry
+from ..functions import _build_labels_values, get_highlights, render_entry
 from ..label_types import get_label_type_module
 from ..ml.services import MLModelService
 from ..tasks.active_learning import train_model
@@ -488,7 +488,6 @@ class QueueSetup(BaseState):
             self.data["queue_required_labels"] = required_labels
             self.data["queue_completion_mode"] = completion_mode
             self.data["queue_position"] = 0
-            self.data["queue_completed"] = []
 
             return 1
 
@@ -509,7 +508,6 @@ class LabelEntry(BaseState):
         queue_required_labels: List of required labels
         queue_completion_mode: "any" or "all" (default: "any")
         queue_position: Current position in queue
-        queue_completed: List of entry IDs that meet completion criteria
         queue_view_mode: "label" or "list" (default: "label")
     """
 
@@ -550,34 +548,45 @@ class LabelEntry(BaseState):
 
         return labels, label_ids, required_label_ids, completion_mode
 
-    def _update_completion(
+    def _compute_completed_entries(
         self,
-        entry_id: str,
-        labels_values: dict,
+        queue_ids: list[str],
         label_ids: list[int],
         required_label_ids: list[int],
         completion_mode: str,
-    ) -> None:
-        """Update completion tracking for an entry."""
-        completed = set(self.data.get("queue_completed", []))
-        if self._check_entry_complete(
-            labels_values, label_ids, required_label_ids, completion_mode
-        ):
-            completed.add(entry_id)
-        else:
-            completed.discard(entry_id)
-        self.data["queue_completed"] = list(completed)
+    ) -> list[str]:
+        """Recompute, from the database, which queue entries meet the completion criteria."""
+        datasets = self.params.get("_datasets", [])
+        completed: list[str] = []
+        for entry_id in queue_ids:
+            entry = None
+            for dataset in datasets:
+                entry = get_entry((dataset.id, entry_id), "composite")
+                if entry is not None:
+                    break
+            if entry is None:
+                continue
+            labels_values = _build_labels_values(entry.labels)
+            if self._check_entry_complete(
+                labels_values, label_ids, required_label_ids, completion_mode
+            ):
+                completed.append(entry_id)
+        return completed
 
     def render(self) -> str:
         queue_ids = self.data.get("queue_ids", [])
         queue_position = self.data.get("queue_position", 0)
-        queue_completed = self.data.get("queue_completed", [])
         view_mode = self.data.get("queue_view_mode", "label")
 
         total = len(queue_ids)
         position = queue_position + 1  # 1-indexed for display
 
         labels, label_ids, required_label_ids, completion_mode = self._get_labels_context()
+
+        # recompute completed entries for the whole queue
+        queue_completed = self._compute_completed_entries(
+            queue_ids, label_ids, required_label_ids, completion_mode
+        )
 
         # List view mode
         if view_mode == "list":
@@ -616,15 +625,6 @@ class LabelEntry(BaseState):
                 break
 
         labels_values = entry_data.get("labels_values", {})
-
-        # Update completion tracking for current entry
-        self._update_completion(
-            current_id,
-            labels_values,
-            label_ids,
-            required_label_ids,
-            completion_mode,
-        )
 
         # Compute missing labels for warning
         check_ids = required_label_ids if required_label_ids else label_ids
@@ -1420,7 +1420,6 @@ class ColdStartSearchSetup(BaseState):
         queue_ids: List of string entry IDs
         queue_labels: [{"id": ..., "name": ...}]
         queue_position: 0
-        queue_completed: []
         queue_required_labels: []
         queue_completion_mode: "any"
     """
@@ -1513,7 +1512,6 @@ class ColdStartSearchSetup(BaseState):
             self.data["queue_ids"] = found_ids
             self.data["queue_labels"] = queue_labels
             self.data["queue_position"] = 0
-            self.data["queue_completed"] = []
             self.data["queue_required_labels"] = []
             self.data["queue_completion_mode"] = "any"
             return 1

--- a/olim/templates/components/search-results.html
+++ b/olim/templates/components/search-results.html
@@ -17,7 +17,7 @@
             </div>
 
             <div class="text-center">
-                <a href="{{url_for('queue', project_id=project_id, queue_id=queue_id)}}"
+                <a href="{{url_for('entry', project_id=project_id, queue_id=queue_id)}}"
                    class="inline-flex items-center px-6 py-3 text-base font-medium text-white bg-cyan-600 rounded-lg hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-cyan-300 transition-colors">
                     <i class="bi bi-send mr-2"></i>
                     {{ _('Open Queue') }}

--- a/olim/templates/entry.html
+++ b/olim/templates/entry.html
@@ -22,7 +22,7 @@
                 {{ _('Previous') }}
             </button>
 
-            <a href="{{ url_for('queue', project_id=project_id, queue_id=queue_id) }}" target="_blank"
+            <a href="{{ url_for('entry', project_id=project_id, queue_id=queue_id) }}" target="_blank"
                 class="flex-1 w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-purple-600 bg-purple-100 border border-purple-300 rounded-lg hover:bg-purple-200 focus:ring-4 focus:outline-none focus:ring-purple-300 transition-colors">
                 <i class="bi bi-list-ol mr-2"></i>
                 {{ queue_pos }}/{{ queue_len }}

--- a/olim/templates/learning-tasks.html
+++ b/olim/templates/learning-tasks.html
@@ -136,32 +136,18 @@
                                         <i class="bi bi-play-fill mr-1"></i>{{ _('Open') }}
                                     </a>
                                     {# Assign dropdown #}
-                                    <div class="relative" x-data="{ open: false }">
-                                        <button type="button" @click="open = !open"
-                                            class="inline-flex items-center px-2.5 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
-                                            {% if task.assignee %}
-                                            <div class="w-4 h-4 bg-cyan-500 rounded-full flex items-center justify-center text-white text-xs font-medium mr-1">{{ task.assignee.name[0]|upper if task.assignee.name else '?' }}</div>
-                                            {{ task.assignee.name or task.assignee.username }}
-                                            {% else %}
-                                            <i class="bi bi-person-plus mr-1"></i>{{ _('Assign') }}
-                                            {% endif %}
-                                        </button>
-                                        <div x-show="open" @click.outside="open = false"
-                                            class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1">
-                                            <form action="{{ url_for('assign_learning_task_route', project_id=project_id, task_id=task.id) }}" method="post">
-                                                <button type="submit" name="assigned_to" value=""
-                                                    class="w-full text-left px-4 py-2 text-xs text-gray-500 hover:bg-gray-50 italic">
-                                                    {{ _('Unassign') }}
-                                                </button>
-                                                {% for user in users %}
-                                                <button type="submit" name="assigned_to" value="{{ user.id }}"
-                                                    class="w-full text-left px-4 py-2 text-xs {% if task.assigned_to == user.id %}text-cyan-700 font-semibold bg-cyan-50{% else %}text-gray-700 hover:bg-gray-50{% endif %}">
-                                                    {{ user.name or user.username }}
-                                                </button>
-                                                {% endfor %}
-                                            </form>
-                                        </div>
-                                    </div>
+                                    <form action="{{ url_for('assign_learning_task_route', project_id=project_id, task_id=task.id) }}"
+                                        method="post" class="inline">
+                                        <label for="assign-{{ task.id }}" class="sr-only">{{ _('Assign To') }}</label>
+                                        <select id="assign-{{ task.id }}" name="assigned_to" onchange="this.form.requestSubmit()"
+                                            class="text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-lg pl-2 pr-8 py-1.5 cursor-pointer focus:ring-2 focus:ring-cyan-200 focus:border-cyan-500 transition-colors
+                                        ">
+                                            <option value="" {% if not task.assignee %}selected{% endif %}>{{ _('unassigned') }}</option>
+                                            {% for user in users %}
+                                            <option value="{{ user.id }}" {% if task.assigned_to == user.id %}selected{% endif %}>{{ user.name or user.username }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </form>
                                     <form action="{{ url_for('reset_learning_task', project_id=project_id, task_id=task.id) }}" method="post" class="inline">
                                         <button type="submit"
                                             class="inline-flex items-center px-2.5 py-1.5 text-xs font-medium text-white bg-yellow-500 rounded-lg hover:bg-yellow-600 transition-colors">
@@ -364,23 +350,5 @@
             configDescription.textContent = configDescriptions[this.value] || '';
         });
     }
-
-    // Alpine-style assign dropdown (plain JS fallback if Alpine not loaded)
-    document.querySelectorAll('[x-data]').forEach(function(el) {
-        if (typeof Alpine === 'undefined') {
-            const btn = el.querySelector('button[type="button"]');
-            const dropdown = el.querySelector('[x-show]');
-            if (btn && dropdown) {
-                dropdown.style.display = 'none';
-                btn.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
-                });
-                document.addEventListener('click', function() {
-                    dropdown.style.display = 'none';
-                });
-            }
-        }
-    });
 </script>
 {% endblock %}

--- a/olim/templates/learning_tasks/queue_list.html
+++ b/olim/templates/learning_tasks/queue_list.html
@@ -128,7 +128,8 @@
 
     <!-- Navigation -->
     <div class="flex justify-between items-center">
-        <form hx-post="" hx-target="#task-content" hx-swap="innerHTML">
+        <form hx-post="" hx-target="#task-content" hx-swap="innerHTML"
+            hx-confirm="{{ _('Going back to setup will reset this task\'s entry queue and its labeling progress. Are you sure you want to continue?') }}">
             <button type="submit" name="action" value="back_to_setup"
                 class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-4 focus:outline-none focus:ring-gray-200 transition-colors">
                 <i class="bi bi-chevron-left mr-2"></i>


### PR DESCRIPTION
Correções de bugs e ajustes de UI no módulo **Learning Tasks** 

-  Erro 500 ao abrir fila em `Data Navigation > Text Search`. Botão "Open Queue" apontava para endpoint inexistente (`queue`). Corrigido para endpoint `entry`;
- Dropdown de atribuição listava usuários apenas na primeira ocorrência do loop no template. `get_users()` retornava um `ScalarResult`, iterator, que era consumido no primeiro laço. Adicionado `.all()` para garantir retorno de `list[User]`;
- "Back to Setup" resetava task sem aviso prévio. Adicionado alert para confirmação antes de voltar para o estado de `QueueSetup`;
- Dropdown de atribuição quebrava o layout da tabela com overflow. Substituição por um `<select>` com ajuste de espaçamento;
- Progresso da queue não aparecia em Queue Overview. `queue_completed` não persistia os dados e não atualizava após anotação de entry.  Passou a ser recalculada a partir do banco para garantir o estado atual da fila independente da redenerização do `LabelEntry` state.